### PR TITLE
make _NODE_EMPTY_PTR a module constant

### DIFF
--- a/src/napari_graph/_base_graph.py
+++ b/src/napari_graph/_base_graph.py
@@ -7,7 +7,14 @@ from numba import njit, typed
 from numba.core import types
 from numpy.typing import ArrayLike
 
+"""
+_NODE_EMPTY_PTR is used to fill the values of uninitialized/empty/removed nodes
+"""
 _NODE_EMPTY_PTR = -1
+
+"""
+_EDGE_EMPTY_PTR is used to fill the values of uninitialized/empty/removed edges
+"""
 _EDGE_EMPTY_PTR = -1
 
 

--- a/src/napari_graph/_base_graph.py
+++ b/src/napari_graph/_base_graph.py
@@ -7,9 +7,7 @@ from numba import njit, typed
 from numba.core import types
 from numpy.typing import ArrayLike
 
-"""
-_EDGE_EMPTY_PTR is used to fill the values of uninitialized/empty/removed nodes or edges
-"""
+_NODE_EMPTY_PTR = -1
 _EDGE_EMPTY_PTR = -1
 
 
@@ -171,8 +169,6 @@ class BaseGraph:
         Optional number of edges to pre-allocate in the graph.
     """
 
-    _NODE_EMPTY_PTR = -1
-
     # abstract constants
     _EDGE_DUPLICATION: int = ...
     _EDGE_SIZE: int = ...
@@ -244,7 +240,7 @@ class BaseGraph:
         )
         self._world2buffer = typed.Dict.empty(types.int64, types.int64)
         self._buffer2world = np.full(
-            n_nodes, fill_value=self._NODE_EMPTY_PTR, dtype=int
+            n_nodes, fill_value=_NODE_EMPTY_PTR, dtype=int
         )
         # edge-wise buffers
         self._empty_edge_idx = 0 if n_edges > 0 else _EDGE_EMPTY_PTR
@@ -322,7 +318,7 @@ class BaseGraph:
 
     def nodes(self) -> np.ndarray:
         """Indices of graph nodes."""
-        return self._buffer2world[self._buffer2world != self._NODE_EMPTY_PTR]
+        return self._buffer2world[self._buffer2world != _NODE_EMPTY_PTR]
 
     def coordinates(
         self, node_indices: Optional[ArrayLike] = None
@@ -367,7 +363,7 @@ class BaseGraph:
         )
         self._buffer2world = np.append(
             self._buffer2world,
-            np.full(size_diff, fill_value=self._NODE_EMPTY_PTR, dtype=int),
+            np.full(size_diff, fill_value=_NODE_EMPTY_PTR, dtype=int),
         )
         self._empty_nodes = list(reversed(range(prev_size, size)))
 
@@ -422,7 +418,7 @@ class BaseGraph:
             index = self._buffer2world[index]
         buffer_index = self._world2buffer.pop(index)
         self._remove_node_edges(buffer_index)
-        self._buffer2world[buffer_index] = self._NODE_EMPTY_PTR
+        self._buffer2world[buffer_index] = _NODE_EMPTY_PTR
         self._empty_nodes.append(buffer_index)
 
     @abstractmethod

--- a/src/napari_graph/directed_graph.py
+++ b/src/napari_graph/directed_graph.py
@@ -6,6 +6,7 @@ from numba import njit, typed
 from numpy.typing import ArrayLike
 
 from napari_graph._base_graph import (
+    _NODE_EMPTY_PTR,
     _EDGE_EMPTY_PTR,
     BaseGraph,
     _iterate_edges,
@@ -381,7 +382,7 @@ class DirectedGraph(BaseGraph):
         super()._realloc_nodes_buffers(size)
         self._node2tgt_edges = np.append(
             self._node2tgt_edges,
-            np.full(diff_size, fill_value=self._NODE_EMPTY_PTR, dtype=int),
+            np.full(diff_size, fill_value=_NODE_EMPTY_PTR, dtype=int),
         )
 
     def _add_edges(self, edges: np.ndarray) -> None:


### PR DESCRIPTION
For consistency with `_EDGE_EMPTY_PTR`, make `_NODE_EMPTY_PTR` a module-level constant