### PR TITLE
refactor __init__

### DIFF
--- a/src/napari_graph/_base_graph.py
+++ b/src/napari_graph/_base_graph.py
@@ -220,7 +220,7 @@ class BaseGraph:
 
         # initialize nodes
         if n_nodes is None:
-            n_nodes = 0
+            n_nodes = self._ALLOC_MIN
         self._init_node_buffers(n_nodes)
         if ndim is not None:
             self._coords = np.empty((n_nodes, ndim), dtype=np.float32)

--- a/src/napari_graph/_base_graph.py
+++ b/src/napari_graph/_base_graph.py
@@ -190,54 +190,73 @@ class BaseGraph:
         n_nodes: Optional[int] = None,
         n_edges: Optional[int] = None,
     ):
+        # validate nodes
+        if coords is not None:
+            if not isinstance(coords, pd.DataFrame):
+                coords = pd.DataFrame(coords)
+            if coords.index.dtype != np.int64:
+                raise ValueError(
+                    f"The index of `coords` (data type: {coords.index.dtype}) must have data type int64."
+                )
 
-        # validating edges length
-        if n_edges is None:
+            # validate nodes: ndim
+            if len(coords.index) > 0:
+                if ndim is not None:
+                    if ndim != len(coords.columns):
+                        raise ValueError(
+                            f"`ndim` ({ndim}) does not match the number of columns in `coords` ({len(coords.columns)})."
+                        )
+                else:
+                    ndim = len(coords.columns)
+
+            # validate nodes: n_nodes
+            if n_nodes is not None:
+                if n_nodes < len(coords.index):
+                    raise ValueError(
+                        f"`n_nodes` ({n_nodes}) must be greater or equal than `coords` length ({len(coords.index)})."
+                    )
+            else:
+                n_nodes = len(coords.index)
+
+        # validate edges
+        edges = np.asarray(edges)
+        if len(edges) > 0:
+            if edges.ndim != 2:
+                raise ValueError(
+                    f"`edges` ({edges.ndim} dimensions) must have 2 dimensions."
+                )
+            if edges.shape[1] != 2:
+                raise ValueError(
+                    f"`edges` (shape: {edges.shape}) must have shape E x 2."
+                )
+
+        # validate edges: n_edges
+        if n_edges is not None:
+            if n_edges < len(edges):
+                raise ValueError(
+                    f"`n_edges` ({n_edges}) must be greater or equal than `edges` length ({len(edges)}."
+                )
+        else:
             n_edges = len(edges)
 
-        if n_edges < len(edges):
-            raise ValueError(
-                f"`n_edges` ({n_edges}) must be greater or equal than `edges` length ({len(edges)}."
-            )
-
-        # validating n_nodes and coords
-        self._coords = None
-        if coords is not None:
-            if ndim is not None:
-                raise ValueError(
-                    "`ndim` and `coords` cannot be supplied at the same time."
-                )
-
-            if not isinstance(coords, pd.DataFrame):
-                coords = np.asarray(coords)
-
-            ndim = coords.shape[1]
-
-            if n_nodes is None:
-                n_nodes = len(coords)
-
-            if n_nodes < len(coords):
-                raise ValueError(
-                    f"`n_nodes` ({n_nodes}) must be greater or equal than `coords` length ({len(coords)})."
-                )
-
-        elif n_nodes is None:
+        # initialize nodes
+        if n_nodes is None:
             n_nodes = 0
-
-        # allocates coords if ndim was provided
+        self._init_node_buffers(n_nodes)
         if ndim is not None:
             self._coords = np.empty((n_nodes, ndim), dtype=np.float32)
-
-        self._init_buffers(n_nodes=n_nodes, n_edges=n_edges)
-
+        else:
+            self._coords = None
         if coords is not None:
+            assert self._coords is not None
             self.init_nodes(coords)
 
+        # initialize edges
+        self._init_edge_buffers(n_edges)
         if len(edges) > 0:
             self.add_edges(edges)
 
-    def _init_buffers(self, n_nodes: int, n_edges: int) -> None:
-        # node-wise buffers
+    def _init_node_buffers(self, n_nodes: int) -> None:
         self._empty_nodes: List[int] = list(reversed(range(n_nodes)))
         self._node2edges = np.full(
             n_nodes, fill_value=_EDGE_EMPTY_PTR, dtype=int
@@ -246,7 +265,8 @@ class BaseGraph:
         self._buffer2world = np.full(
             n_nodes, fill_value=self._NODE_EMPTY_PTR, dtype=int
         )
-        # edge-wise buffers
+
+    def _init_edge_buffers(self, n_edges: int) -> None:
         self._empty_edge_idx = 0 if n_edges > 0 else _EDGE_EMPTY_PTR
         self._n_edges = 0
         self._edges_buffer = np.full(

--- a/src/napari_graph/_base_graph.py
+++ b/src/napari_graph/_base_graph.py
@@ -218,6 +218,18 @@ class BaseGraph:
             else:
                 n_nodes = len(coords.index)
 
+        # initialize nodes
+        if n_nodes is None:
+            n_nodes = 0
+        self._init_node_buffers(n_nodes)
+        if ndim is not None:
+            self._coords = np.empty((n_nodes, ndim), dtype=np.float32)
+        else:
+            self._coords = None
+        if coords is not None:
+            assert self._coords is not None
+            self.init_nodes(coords)
+
         # validate edges
         edges = np.asarray(edges)
         if len(edges) > 0:
@@ -238,18 +250,6 @@ class BaseGraph:
                 )
         else:
             n_edges = len(edges)
-
-        # initialize nodes
-        if n_nodes is None:
-            n_nodes = 0
-        self._init_node_buffers(n_nodes)
-        if ndim is not None:
-            self._coords = np.empty((n_nodes, ndim), dtype=np.float32)
-        else:
-            self._coords = None
-        if coords is not None:
-            assert self._coords is not None
-            self.init_nodes(coords)
 
         # initialize edges
         self._init_edge_buffers(n_edges)

--- a/src/napari_graph/directed_graph.py
+++ b/src/napari_graph/directed_graph.py
@@ -348,8 +348,8 @@ class DirectedGraph(BaseGraph):
     _EDGE_SIZE = _DI_EDGE_SIZE
     _LL_EDGE_POS = _LL_DI_EDGE_POS
 
-    def _init_buffers(self, n_nodes: int, n_edges: int) -> None:
-        super()._init_buffers(n_nodes, n_edges)
+    def _init_node_buffers(self, n_nodes: int) -> None:
+        super()._init_node_buffers(n_nodes)
         self._node2tgt_edges = np.full(
             n_nodes, fill_value=_EDGE_EMPTY_PTR, dtype=int
         )


### PR DESCRIPTION
Hi @JoOkuma,

I found `BaseGraph.__init__` a bit hard to parse and attempted to refactor it:
- `__init__` is structured into validation and initialization, where validation also infers dimensions
- `__init__` now allows specifying all arguments (including `coords` + `ndim`), as long as everything matches
- `_init_buffers` has been split up into `_init_node_buffers` and `_init_edge_buffers`

Just let me know what you think - also happy to revert back to your original version if you don't like it!